### PR TITLE
[CHNCY-018] Remove focus from checkbox when clicked

### DIFF
--- a/src/components/FilterBox.js
+++ b/src/components/FilterBox.js
@@ -118,6 +118,7 @@ function FilterBox() {
       : setSelectedTopics(
           selectedTopics.filter((selectedTopic) => selectedTopic !== topic)
         );
+    event.target.blur();
   };
 
   const applyDifficultyFilters = (event, difficulty) => {
@@ -129,6 +130,7 @@ function FilterBox() {
             (selectedDifficulty) => selectedDifficulty !== difficulty
           )
         );
+    event.target.blur();
   };
 
   const clearFilters = () => {


### PR DESCRIPTION
**Issue:**
After selecting a filter, users are required to click out of the filter box to use the flashcard hotkeys.
This is because the nature of the checkbox will keep the focus on the checkbox when clicked.

**Solution:**
Use event.target.blur() to unfocus the checkbox when the checkbox is clicked.

**Risk:**
No risks identified

**Reviewed By:**
Francis
