### PR TITLE
[CHNCY-004] Flashcard paragraphing console fix

### DIFF
--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -306,7 +306,7 @@ function Flashcard() {
               >
                 A.&emsp;
               </Typography>
-              <AnswerContent id="answer-content">
+              <AnswerContent id="answer-content" component={'span'}>
                 <pre>{currentFlashcard.answer}</pre>
               </AnswerContent>
               {!show && (


### PR DESCRIPTION
**Issue:**
Console errors occur when using the <.pre> tag. This is mainly because MaterialUI Typography is default <.p> and it can only contain in-line elements.

**Solution:**
Changed the AnswerContent to be type 'span'. 
https://stackoverflow.com/questions/41928567/div-cannot-appear-as-a-descendant-of-p 

**Risk:**
No risks identified

**Reviewed By:**
Steven