### PR TITLE
[CHNCY-020] Updated consistency when swapping between tabs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -108,7 +108,7 @@ function App() {
     const dispatch = useDispatch();
     useEffect(() => {
         dispatch(fetchQuestions());
-    });
+    }, []);
 
     window.onkeydown = function (e) {
         if (document.URL.includes("revise")) {

--- a/src/components/FilterBox.js
+++ b/src/components/FilterBox.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormGroup from "@material-ui/core/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
@@ -8,10 +8,11 @@ import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
 import clsx from "clsx";
-import { useDispatch } from "react-redux";
-import { updateFilters } from "../redux/actions";
+import { useDispatch, useSelector } from "react-redux";
+import { updateFilters, resetFilters } from "../redux/actions";
 import Grid from "@material-ui/core/Grid";
 import * as constants from "../redux/constants";
+import allFalse from '../helperFunctions/allFalse';
 
 const useStyles = makeStyles((theme) => ({
   heading: {
@@ -84,68 +85,33 @@ function StyledCheckbox(props) {
 
 function FilterBox() {
   const classes = useStyles();
-  const loaded = useRef(false);
   const dispatch = useDispatch();
 
-  const topics = [
-    constants.ACCOUNTING,
-    constants.EV_EQUITY_VALUE,
-    constants.VALUATION,
-    constants.DISCOUNTED_CASH_FLOW,
-    constants.MERGER_MODEL,
-    constants.LEVERAGED_BUY_OUT,
-  ];
-  const difficulties = [constants.EASY, constants.MEDIUM, constants.HARD];
-
-  const [selectedTopics, setSelectedTopics] = useState([]);
-  const [selectedDifficulties, setSelectedDifficulties] = useState([]);
-  const initialCheckboxStates = {};
-
-  topics.forEach(topic => {
-    initialCheckboxStates[topic] = false;
-  });
-
-  difficulties.forEach(difficulty => {
-    initialCheckboxStates[difficulty] = false;
-  });
-
-  const [checkedStates, setCheckedStates] = useState(initialCheckboxStates);
+  const topics = constants.topics;
+  const difficulties = constants.difficulties;
+  const savedTopics = useSelector(state => state.topics);
+  const savedDifficulties = useSelector(state => state.difficulties);
+  const [checkedStates, setCheckedStates] = useState({...savedTopics, ...savedDifficulties});
 
   const applyTopicFilters = (event, topic) => {
-    setCheckedStates({...checkedStates, [topic]: event.target.checked});
-    event.target.checked
-      ? setSelectedTopics(selectedTopics.concat(topic))
-      : setSelectedTopics(
-          selectedTopics.filter((selectedTopic) => selectedTopic !== topic)
-        );
+    dispatch(updateFilters({...savedTopics, [topic]: event.target.checked}, savedDifficulties));
     event.target.blur();
   };
 
   const applyDifficultyFilters = (event, difficulty) => {
-    setCheckedStates({...checkedStates, [difficulty]: event.target.checked});
-    event.target.checked
-      ? setSelectedDifficulties(selectedDifficulties.concat(difficulty))
-      : setSelectedDifficulties(
-          selectedDifficulties.filter(
-            (selectedDifficulty) => selectedDifficulty !== difficulty
-          )
-        );
+    dispatch(updateFilters(savedTopics, {...savedDifficulties, [difficulty]: event.target.checked}));
     event.target.blur();
   };
 
   const clearFilters = () => {
-    setCheckedStates(initialCheckboxStates);
-    setSelectedDifficulties([]);
-    setSelectedTopics([]);
+    if (!allFalse(checkedStates)) {
+      dispatch(resetFilters());
+    }
   };
 
   useEffect(() => {
-    if (loaded.current) {
-      dispatch(updateFilters(selectedTopics, selectedDifficulties));
-    } else {
-      loaded.current = true;
-    }
-  }, [selectedTopics, selectedDifficulties]);
+    setCheckedStates({...savedTopics, ...savedDifficulties});
+  }, [savedTopics, savedDifficulties]);
   
   const topicCheckBoxes = topics.map((topic) => (
     <FormControlLabel

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -183,11 +183,7 @@ function Flashcard() {
 
   useEffect(() => {
     setCurrentFlashcard(displayedFlashcards[currentIndex]);
-  }, [displayedFlashcards]);
-
-  useEffect(() => {
-    setCurrentFlashcard(displayedFlashcards[currentIndex]);
-  }, [currentIndex]);
+  }, [displayedFlashcards, currentIndex]);
 
   const [show, setShowAnswer] = useState(false);
   const [saved, setSaved] = useState(false);

--- a/src/helperFunctions/allFalse.js
+++ b/src/helperFunctions/allFalse.js
@@ -1,0 +1,8 @@
+function allFalse(filterList)
+{
+    for(var filter in filterList)
+        if(filterList[filter]) return false;
+    return true;
+}
+
+export default allFalse;

--- a/src/helperFunctions/shuffle.js
+++ b/src/helperFunctions/shuffle.js
@@ -1,0 +1,25 @@
+/**
+   * shuffle the order of the flashcards array
+   * @param {*} array 
+   * resource: https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+   */
+  function shuffle(array) {
+    let currentIndex = array.length, temporaryValue, randomIndex;
+  
+    // While there remain elements to shuffle...
+    while (0 !== currentIndex) {
+  
+      // Pick a remaining element...
+      randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+  
+      // And swap it with the current element.
+      temporaryValue = array[currentIndex];
+      array[currentIndex] = array[randomIndex];
+      array[randomIndex] = temporaryValue;
+    }
+  
+    return array;
+  }
+
+  export default shuffle;

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -12,6 +12,22 @@ export const updateFilters = (selectedTopics, selectedDifficulties) => {
     return { type: constants.UPDATE_FILTERS, payload: {topics: selectedTopics, difficulties: selectedDifficulties}};
 }
 
-export const updateFiltersSuccess = ids => {
-    return { type: constants.UPDATE_FILTERS_SUCCESS, payload: ids};
+export const updateFiltersSuccess = (flashcards, topics, difficulties) => {
+    return { type: constants.UPDATE_FILTERS_SUCCESS, payload: {flashcards: flashcards, topics: topics, difficulties: difficulties}};
+}
+
+export const resetFilters = () => {
+    return { type: constants.RESET_FILTERS};
+}
+
+export const resetFiltersSuccess = flashcards => {
+    return { type: constants.RESET_FILTERS_SUCCESS, payload: flashcards}
+}
+
+export const updateCurrentIndex = index => {
+    return { type: constants.UPDATE_CURRENT_INDEX, payload: index }
+}
+
+export const updateCurrentIndexSuccess = index => {
+    return { type: constants.UPDATE_CURRENT_INDEX_SUCCESS, payload: index }
 }

--- a/src/redux/constants.js
+++ b/src/redux/constants.js
@@ -8,6 +8,14 @@ export const UPDATE_FILTERS = 'UPDATE_FILTERS';
 
 export const UPDATE_FILTERS_SUCCESS = 'UPDATE_FILTERS_SUCCESS';
 
+export const RESET_FILTERS = 'RESET_FILTERS';
+
+export const RESET_FILTERS_SUCCESS = 'RESET_FILTERS_SUCCESS';
+
+export const UPDATE_CURRENT_INDEX = 'UPDATE_CURRENT_INDEX';
+
+export const UPDATE_CURRENT_INDEX_SUCCESS = 'UPDATE_CURRENT_INDEX_SUCCESS';
+
 // Filter Headings
 
 export const EASY = 'Easy'; 
@@ -27,3 +35,14 @@ export const DISCOUNTED_CASH_FLOW = 'Discounted Cash Flow';
 export const MERGER_MODEL = 'Merger Model';
 
 export const LEVERAGED_BUY_OUT = 'Leveraged Buyout';
+
+export const topics = [
+    ACCOUNTING,
+    EV_EQUITY_VALUE,
+    VALUATION,
+    DISCOUNTED_CASH_FLOW,
+    MERGER_MODEL,
+    LEVERAGED_BUY_OUT,
+  ];
+
+export const difficulties = [EASY, MEDIUM, HARD];

--- a/src/redux/epic.js
+++ b/src/redux/epic.js
@@ -1,27 +1,71 @@
-import { combineEpics } from 'redux-observable';
-import { mergeMap, map } from 'rxjs/operators';
-import { getFlashcards } from '../api/chanceryApi';
-import * as constants from './constants';
-import {fetchQuestionsSuccess, updateFiltersSuccess} from './actions';
+import { combineEpics } from "redux-observable";
+import { mergeMap, map } from "rxjs/operators";
+import { getFlashcards } from "../api/chanceryApi";
+import * as constants from "./constants";
+import {
+  fetchQuestionsSuccess,
+  updateFiltersSuccess,
+  resetFiltersSuccess,
+  updateCurrentIndexSuccess,
+} from "./actions";
+import allFalse from "../helperFunctions/allFalse";
+import shuffle from "../helperFunctions/shuffle";
 
 export const fetchQuestionsEpic = (action$, state$) =>
-action$.ofType(constants.FETCH_QUESTIONS).pipe(
+  action$.ofType(constants.FETCH_QUESTIONS).pipe(
     mergeMap(async () => {
-        const result = await getFlashcards();
-        return fetchQuestionsSuccess(result);
-    })    
-);
+      const result = await getFlashcards();
+      shuffle(result);
+      return fetchQuestionsSuccess(result);
+    })
+  );
 
 export const updateFiltersEpic = (action$, state$) =>
-action$.ofType(constants.UPDATE_FILTERS).pipe(
-    map( action => {
-        const flashcardsByTopic = state$.value.flashcards.filter(flashcard => action.payload.topics.length === 0 || action.payload.topics.includes(flashcard.topic));
-        const filteredFlashcardsId = flashcardsByTopic.filter(flashcard => action.payload.difficulties.length === 0 || action.payload.difficulties.includes(flashcard.difficulty)).map(flashcard => flashcard.id);
-        return updateFiltersSuccess(filteredFlashcardsId);
+  action$.ofType(constants.UPDATE_FILTERS).pipe(
+    map((action) => {
+      const flashcardsByTopic = state$.value.flashcards.filter(
+        (flashcard) =>
+          allFalse(action.payload.topics) ||
+          action.payload.topics[flashcard.topic]
+      );
+      const filteredFlashcards = flashcardsByTopic.filter(
+        (flashcard) =>
+          allFalse(action.payload.difficulties) ||
+          action.payload.difficulties[flashcard.difficulty]
+      );
+      shuffle(filteredFlashcards);
+
+      return updateFiltersSuccess(
+        filteredFlashcards,
+        action.payload.topics,
+        action.payload.difficulties
+      );
     })
-);
+  );
+
+export const resetFiltersEpic = (action$, state$) =>
+  action$.ofType(constants.RESET_FILTERS).pipe(
+    map(() => {
+      const flashcards = state$.value.flashcards;
+      shuffle(flashcards);
+      return resetFiltersSuccess(flashcards);
+    })
+  );
+
+export const updateCurrentIndexEpic = (action$, state$) =>
+  action$.ofType(constants.UPDATE_CURRENT_INDEX).pipe(
+    map((action) => {
+      const currentIndex =
+        (action.payload + state$.value.displayedFlashcards.length) %
+        state$.value.displayedFlashcards.length;
+
+      return updateCurrentIndexSuccess(currentIndex);
+    })
+  );
 
 export const rootEpic = combineEpics(
-    fetchQuestionsEpic,
-    updateFiltersEpic,
+  fetchQuestionsEpic,
+  updateFiltersEpic,
+  resetFiltersEpic,
+  updateCurrentIndexEpic
 );

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,25 +1,58 @@
-import * as constants from './constants';
+import * as constants from "./constants";
+
+let initialDifficulties = {};
+let initialTopics = {};
+
+constants.topics.forEach((topic) => {
+  initialTopics[topic] = false;
+});
+
+constants.difficulties.forEach((difficulty) => {
+  initialDifficulties[difficulty] = false;
+});
 
 export const initialState = {
-    flashcards: [],
-    displayedFlashcards: [],
+  flashcards: [],
+  displayedFlashcards: [],
+  difficulties: initialDifficulties,
+  topics: initialTopics,
+  currentIndex: 0,
 };
 
 export const reducer = (state = initialState, action) => {
-    switch(action.type) {
-        case constants.FETCH_QUESTIONS_SUCCESS:
-            return {
-                ...state, 
-                flashcards: action.payload,
-            };
+  switch (action.type) {
+    case constants.FETCH_QUESTIONS_SUCCESS:
+      return {
+        ...state,
+        flashcards: action.payload,
+        displayedFlashcards: action.payload,
+      };
 
-        case constants.UPDATE_FILTERS_SUCCESS:
-            return {
-                ...state, 
-                displayedFlashcards: action.payload,
-            }
+    case constants.UPDATE_FILTERS_SUCCESS:
+      return {
+        ...state,
+        displayedFlashcards: action.payload.flashcards,
+        difficulties: action.payload.difficulties,
+        topics: action.payload.topics,
+        currentIndex: 0,
+      };
 
-        default:
-            return state;
-    }
+    case constants.RESET_FILTERS_SUCCESS:
+      return {
+        ...state,
+        difficulties: initialDifficulties,
+        topics: initialTopics,
+        displayedFlashcards: action.payload,
+        currentIndex: 0,
+      };
+
+    case constants.UPDATE_CURRENT_INDEX_SUCCESS:
+      return {
+        ...state,
+        currentIndex: action.payload,
+      };
+
+    default:
+      return state;
+  }
 };


### PR DESCRIPTION
**Issue:**
There was a grey area regarding what should happen to the displayed flashcard when a user moved between the tabs.
Swapping between light and dark mode would cause a shuffle of the order. 
Swapping tabs would reset the whole flashcards but not update the filters to match what was being displayed.

**Solution:**
Changed a useEffect() to only occur on first load - this prevents flashcards shuffling every time the mode is changed.
Discussed with other devs and product owners how the consistency should be: 
- When a user refreshes or loads a fresh instance of the web application, a new order should be generated. 
- Every time a user moves within the tabs, the state of the revise page should remain the same - this is to be done through refactoring currentFlashcard and relevant information into the redux store, so the state is kept within the tabs and will not reset on every rerender of the revise tab.

**Risk:**
No risks identified.

**Reviewed By:**
Yuno