### PR TITLE
[CHNCY-009] Tag component resizing fix

### DIFF
--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -229,20 +229,20 @@ function Flashcard() {
           className={classes.flashcardBackground}
         >
           <React.Fragment>
-            <Grid container justify="center" alignItems="center">
-              <Grid item container xs={5} md={4}>
+            <Grid container justify="center">
+              <Grid item container xs={5}>
                 <Tag text={currentFlashcard.topic} />
                 <Tag text={currentFlashcard.difficulty} />
               </Grid>
-              <Grid item container xs={2} md={4} justify="center">
+              <Grid item container xs={2} justify="center">
                 <Typography id="flashcard-id" className={classes.page}>
                   {currentIndex + 1} &nbsp;/&nbsp; {displayedFlashcards.length}
                 </Typography>
               </Grid>
-              <Grid item container xs={5} md={4} justify="flex-end">
+              <Grid item container xs={5} justify="flex-end" style={{ height: '40px' }}>
                 <Typography
                   className={classes.subheading}
-                  style={{ fontSize: 25, marginTop: 3 }}
+                  style={{ fontSize: 25, marginTop: 8 }}
                 >
                   Save&nbsp;
                 </Typography>

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -236,7 +236,7 @@ function Flashcard() {
               </Grid>
               <Grid item container xs={2} justify="center">
                 <Typography id="flashcard-id" className={classes.page}>
-                  {currentIndex + 1} &nbsp;/&nbsp; {displayedFlashcards.length}
+                  {currentIndex + 1} / {displayedFlashcards.length}
                 </Typography>
               </Grid>
               <Grid item container xs={5} justify="flex-end" style={{ height: '40px' }}>

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -24,12 +24,14 @@ import { useHotkeys } from "react-hotkeys-hook";
 const useStyles = makeStyles((theme) => ({
   page: {
     color: theme.palette.type === "dark" ? "#fff" : "#818181",
-    fontSize: "43px",
+    fontSize: "35px",
     display: "inline-block",
+    lineHeight: "40px",
+    marginTop: '5px',
   },
   save: {
     float: "right",
-    margin: "-5px -15px 0 -15px",
+    margin: "0px -15px 0 -15px",
     "&:hover": {
       background: "none",
       borderWidth: "3px",
@@ -49,7 +51,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.default,
     borderRadius: "10px",
     textAlign: "center",
-    padding: "20px 30px 100px 30px",
+    padding: "20px 30px 100px 20px",
     position: "relative",
     boxShadow: theme.palette.type === "dark" ? "none" : "0 0 5px 0 grey",
     display: "flex",
@@ -139,7 +141,7 @@ const useStyles = makeStyles((theme) => ({
 
   leftButton: {
     position: "absolute",
-    left: "calc(5% - 15px)",
+    left: "calc(5% - 20px)",
     top: "calc(200px)",
 
     color: "#F5F5F5",
@@ -150,7 +152,7 @@ const useStyles = makeStyles((theme) => ({
   },
   rightButton: {
     position: "absolute",
-    right: "calc(5% - 15px)",
+    right: "calc(5% - 20px)",
     top: "calc(200px)",
 
     color: "#F5F5F5",

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -230,7 +230,7 @@ function Flashcard() {
         >
           <React.Fragment>
             <Grid container justify="center">
-              <Grid item container xs={5}>
+              <Grid item container xs={5} style={{paddingRight: '40px'}}>
                 <Tag text={currentFlashcard.topic} />
                 <Tag text={currentFlashcard.difficulty} />
               </Grid>

--- a/src/components/HotkeyBox.js
+++ b/src/components/HotkeyBox.js
@@ -69,7 +69,7 @@ function HotkeyBox() {
 
           <Typography className={classes.information}>
             <img src={Save} className={"hotkey-icon"} alt="Save Key"/>
-            <b>Save </b>- S key to save your questions for later
+            <b>Save </b>- Press the S key to save a question
           </Typography>
         </Grid>
       </Grid>

--- a/src/components/HotkeyBox.js
+++ b/src/components/HotkeyBox.js
@@ -69,7 +69,7 @@ function HotkeyBox() {
 
           <Typography className={classes.information}>
             <img src={Save} className={"hotkey-icon"} alt="Save Key"/>
-            <b>Save </b>- Press the S key to save a question
+            <b>Save </b>- S key to save your questions for later
           </Typography>
         </Grid>
       </Grid>

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -25,7 +25,6 @@ const useStyles = makeStyles(() => ({
         position: 'absolute',
         top: '9px',
         fontSize: 20,
-        fontSize: 18,
         color: "white",
         paddingRight: 5,
     }

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -6,18 +6,25 @@ import Typography from "@material-ui/core/Typography";
 
 const useStyles = makeStyles(() => ({
     container: {
+        position: 'relative',
         backgroundColor: "#21CE99",
         borderRadius: 5,
-        padding: '4px 15px 4px 10px',
-        margin: 5,
+        padding: '5px 15px 5px 10px',
+        margin: '5px',
+        minHeight: '30px',
     },
     text: {
         color: "white",
         fontSize: "18px",
         textTransform: "uppercase",
-        float: "left",
+        lineHeight: '30px',
+        textAlign: 'left',
+        marginLeft: '25px',
     },
     icon: {
+        position: 'absolute',
+        top: '9px',
+        fontSize: 20,
         fontSize: 18,
         color: "white",
         paddingRight: 5,
@@ -29,7 +36,7 @@ function Tag(props) {
 
     return (
         <div className={classes.container}>
-            <Grid container alignItems={"center"}>
+            <Grid container>
                 <LocalOfferIcon className={classes.icon} />
                 <Typography id="topic" className={classes.text}>
                     {props.text}


### PR DESCRIPTION
**Issue:**
For smaller screens, long tags do not wrap correctly.

**Solution:**
Use relative positioning to appropriately position the icon to the right of the tag and text-align the subsequent label to the left. 

**Risk:**
There is still empty space caused by the wrapping of the text, and the width of the tag changes variably as a result. 

**Reviewed By:**
[Edit the message as to who reviewed it here]
