### PR TITLE
[CHNCY-017] Fix flashcard resizing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -59,3 +59,7 @@ pre {
   font-size: 20px;
   line-height: 40px;
  }
+
+ html {
+   overflow-y: scroll;
+ }

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -75,7 +75,7 @@ const useStyles = makeStyles((theme) => ({
     position: "relative",
     padding: "15px 25px 15px 25px",
     marginTop: "30px",
-    height: "200px",
+    minHeight: "200px",
     width: "80%",
     display: "flex",
   },

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -217,7 +217,7 @@ function Flashcard() {
   }, [move]);
 
   return (
-    <div style={{ height: "100%", maxWidth: 1150 }}>
+    <div style={{ height: "100%" }}>
       {currentFlashcard === undefined ? (
         <Grid container justify="center" alignItems="center">
           <CircularProgress />

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -7,10 +7,9 @@ import HotkeyBox from "../components/HotkeyBox";
 function Revise() {
 
     return (
-        <div style={{ position: "relative", paddingTop: '10vh' }}>
             <Grid
                 container
-                style={{ minHeight: '90vh', padding: '3em 7em 0em 7em'}}
+                style={{ minHeight: '100vh', padding: '15vh 7em 0em 7em'}}
                 justify={"center"}
             >
                 <Grid container item md={12} >
@@ -27,7 +26,6 @@ function Revise() {
                     </Grid>
                 </Grid>
             </Grid>
-        </div>
 
     )
 }

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -3,21 +3,30 @@ import Grid from '@material-ui/core/Grid';
 import FilterBox from '../components/FilterBox';
 import Flashcard from '../components/Flashcard';
 import HotkeyBox from "../components/HotkeyBox";
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+        minHeight: '100vh' - theme.spacing(5),
+        padding: '15vh 7em 0em 7em'
+    }
+}));
 
 function Revise() {
+    const classes = useStyles();
 
     return (
             <Grid
                 container
-                style={{ minHeight: '100vh', padding: '15vh 7em 0em 7em'}}
+                className={classes.root}
                 justify={"center"}
             >
-                <Grid container item md={12} >
+                <Grid container item md={12} spacing={5}>
                     <Grid container item lg={4} xl={3} justify={"center"}>
                         <FilterBox/>
                     </Grid>
                     <Grid container direction={"column"} item lg={8} xl={9} alignItems={"center"}>
-                        <Grid item>
+                        <Grid item style={{width: '100%'}}>
                             <Flashcard/>
                         </Grid>
                         <Grid item>


### PR DESCRIPTION
**Issue:**
Flashcard size kept changing due to two reasons:
1) The scroll bar repositions the page
2) Answers with small content reduce the flashcard width

**Solution:**
1) Made scrollbar always present [see Risk]
2) Made grid items take up 100% width, and utilised grid spacing to control the positioning

**Risk:**
Having the scrollbar always present is unattractive

**Reviewed By:**
[Edit the message as to who reviewed it here]
