### PR TITLE
Chnry 025/responsiveness

### DIFF
--- a/src/components/FilterBox.js
+++ b/src/components/FilterBox.js
@@ -52,7 +52,6 @@ const useStyles = makeStyles((theme) => ({
   filterBox: {
     backgroundColor: theme.palette.background.default,
     borderRadius: "10px",
-    height: "760px",
     width: "365px",
     boxShadow: theme.palette.type === "dark" ? "none" : "0 0 5px 0 grey",
   },
@@ -112,7 +111,7 @@ function FilterBox() {
   useEffect(() => {
     setCheckedStates({...savedTopics, ...savedDifficulties});
   }, [savedTopics, savedDifficulties]);
-  
+
   const topicCheckBoxes = topics.map((topic) => (
     <FormControlLabel
       style={{ padding: "6px" }}

--- a/src/components/FilterBox.js
+++ b/src/components/FilterBox.js
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
   filterBox: {
     backgroundColor: theme.palette.background.default,
     borderRadius: "10px",
-    width: "365px",
+	padding: "20px",
     boxShadow: theme.palette.type === "dark" ? "none" : "0 0 5px 0 grey",
   },
   button: {
@@ -141,7 +141,7 @@ function FilterBox() {
       className={classes.filterBox}
       container
       direction="column"
-      justify="center"
+      justify="start"
       alignItems="center"
     >
       <Grid item style={{ paddingLeft: 20 }}>

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -149,6 +149,9 @@ const useStyles = makeStyles((theme) => ({
 
     height: "60px",
     width: "60px",
+	"&:hover": {
+      backgroundColor: "#B1B1B1",
+	}
   },
   rightButton: {
     position: "absolute",
@@ -160,6 +163,9 @@ const useStyles = makeStyles((theme) => ({
 
     height: "60px",
     width: "60px",
+	"&:hover": {
+	  backgroundColor: "#B1B1B1",
+	}
   },
 }));
 

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -223,7 +223,7 @@ function Flashcard() {
   }, [move]);
 
   return (
-    <div style={{ height: "100%" }}>
+    <div style={{ height: "100%" }} id="top">
       {currentFlashcard === undefined ? (
         <Grid container justify="center" alignItems="center">
           <CircularProgress />
@@ -312,6 +312,7 @@ function Flashcard() {
             {show && (
               <Button
                 id="show-button"
+				href="#top"
                 className={classes.hideButton}
                 color="primary"
                 variant={"contained"}

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -174,6 +174,15 @@ const useStyles = makeStyles((theme) => ({
   	rightButton: {
 	  right: "0",
 	  marginRight: "-14px",
+	},
+	questionContainer: {
+	  width: "100%",
+	},
+	questionContent: {
+	  fontSize: "20px",
+	},
+	answerContainer: {
+	  width: "100%",
 	}
   }
 }));

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -74,7 +74,6 @@ const useStyles = makeStyles((theme) => ({
     textAlign: "left",
     position: "relative",
     padding: "15px 25px 15px 25px",
-    marginTop: "30px",
     minHeight: "200px",
     width: "80%",
     display: "flex",
@@ -167,6 +166,16 @@ const useStyles = makeStyles((theme) => ({
 	  backgroundColor: "#B1B1B1",
 	}
   },
+  '@media (max-width: 960px)': {
+	leftButton: {
+	  left: "0",
+	  marginLeft: "-14px",
+	},
+  	rightButton: {
+	  right: "0",
+	  marginRight: "-14px",
+	}
+  }
 }));
 
 function Flashcard() {

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -236,16 +236,16 @@ function Flashcard() {
         >
           <React.Fragment>
             <Grid container justify="center">
-              <Grid item container xs={5} style={{paddingRight: '40px'}}>
+              <Grid item container xs={12} md={5} style={{paddingRight: '40px'}}>
                 <Tag text={currentFlashcard.topic} />
                 <Tag text={currentFlashcard.difficulty} />
               </Grid>
-              <Grid item container xs={2} justify="center">
+              <Grid item container xs={12} md={2} justify="center">
                 <Typography id="flashcard-id" className={classes.page}>
                   {currentIndex + 1} / {displayedFlashcards.length}
                 </Typography>
               </Grid>
-              <Grid item container xs={5} justify="flex-end" style={{ height: '40px' }}>
+              <Grid item container xs={12} md={5} justify="flex-end" style={{ height: '40px' }}>
                 <Typography
                   className={classes.subheading}
                   style={{ fontSize: 25, marginTop: 8 }}

--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -101,6 +101,7 @@ const useStyles = makeStyles((theme) => ({
     transform: "translate(-50%, -50%)",
 
     width: "210px",
+	maxWidth: "100%",
 
     "&:hover": {
       borderWidth: "3px",
@@ -127,6 +128,7 @@ const useStyles = makeStyles((theme) => ({
     left: "calc(50% - 105px)",
 
     width: "210px",
+	maxWidth: "100%",
 
     "&:hover": {
       borderStyle: "solid",

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -21,6 +21,9 @@ const useStyles = makeStyles(() => ({
         lineHeight: '30px',
         textAlign: 'left',
         marginLeft: '25px',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap',
     },
     icon: {
         position: 'absolute',

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles(() => ({
         borderRadius: 5,
         padding: '5px 15px 5px 10px',
         margin: '5px',
-        minHeight: '30px',
+        height: '30px',
     },
     text: {
         color: "white",
@@ -28,7 +28,7 @@ const useStyles = makeStyles(() => ({
         color: "white",
         paddingRight: 5,
     }
-}))
+}));
 
 function Tag(props) {
     const classes = useStyles();

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -12,6 +12,7 @@ const useStyles = makeStyles(() => ({
         padding: '5px 15px 5px 10px',
         margin: '5px',
         height: '30px',
+		maxWidth: '100%',
     },
     text: {
         color: "white",

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -24,8 +24,10 @@ function Revise() {
                 justify={"center"}
             >
                 <Grid container item md={12} spacing={5}>
-                    <Grid container item lg={4} xl={3} justify={"center"}>
-                        <FilterBox/>
+                    <Grid container item lg={4} xl={3} justify={"center"} alignItems={"start"}>
+						<div>
+                        	<FilterBox/>
+						</div>
                     </Grid>
                     <Grid container direction={"column"} item lg={8} xl={9} alignItems={"center"}>
                         <Grid item style={{width: '100%'}}>

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -8,7 +8,9 @@ import {makeStyles} from "@material-ui/core/styles";
 const useStyles = makeStyles((theme) => ({
     root: {
         minHeight: '100vh' - theme.spacing(5),
-        padding: '15vh 7em 0em 7em'
+        padding: '15vh 7em 0em 7em',
+		maxWidth: '2560px',
+		margin: '0 auto',
     }
 }));
 

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -24,7 +24,7 @@ function Revise() {
                 className={classes.root}
                 justify={"center"}
             >
-                <Grid container item md={12} spacing={5}>
+                <Grid container item md={12} spacing={4}>
                     <Grid container item lg={4} xl={3} justify={"center"} alignItems={"start"}>
 						<div>
                         	<FilterBox/>

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -8,7 +8,7 @@ import {makeStyles} from "@material-ui/core/styles";
 const useStyles = makeStyles((theme) => ({
     root: {
         minHeight: '100vh' - theme.spacing(5),
-        padding: '15vh 7em 0em 7em',
+        padding: '102px 7em 0em 7em',
 		maxWidth: '2560px',
 		margin: '0 auto',
     }

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -4,6 +4,7 @@ import FilterBox from '../components/FilterBox';
 import Flashcard from '../components/Flashcard';
 import HotkeyBox from "../components/HotkeyBox";
 import {makeStyles} from "@material-ui/core/styles";
+import Box from "@material-ui/core/Box";
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -33,9 +34,11 @@ function Revise() {
                         <Grid item style={{width: '100%'}}>
                             <Flashcard/>
                         </Grid>
-                        <Grid item>
-                            <HotkeyBox/>
-                        </Grid>
+						<Grid item>
+                        	<Box display={{ xs: 'none', md: 'block' }}>
+                            	<HotkeyBox/>
+                        	</Box>
+						</Grid>
                     </Grid>
                 </Grid>
             </Grid>

--- a/src/pages/revise.js
+++ b/src/pages/revise.js
@@ -8,7 +8,7 @@ import {makeStyles} from "@material-ui/core/styles";
 const useStyles = makeStyles((theme) => ({
     root: {
         minHeight: '100vh' - theme.spacing(5),
-        padding: '102px 7em 0em 7em',
+        padding: '102px 1em 0em',
 		maxWidth: '2560px',
 		margin: '0 auto',
     }

--- a/src/pages/saved.js
+++ b/src/pages/saved.js
@@ -10,6 +10,10 @@ import Grid from "@material-ui/core/Grid";
 import { Link } from "react-router-dom";
 
 const useStyles = makeStyles({
+  root: {
+	maxWidth: '2560px',
+	margin: '0 auto',
+  },
   title: {
     fontSize: "40px",
     fontWeight: "bold",
@@ -80,7 +84,7 @@ function detectScrollDown() {
 }
 
 function Saved() {
-    
+
   const classes = useStyles();
 
   detectScrollDown();


### PR DESCRIPTION
**Issue:**
Responsive is a big issue on the website. I edit the styles to make the revise page more accessible on mobile screens as well as extra wide desktop screens. 
![SS 2020-11-05 at 2 40 55 pm](https://user-images.githubusercontent.com/49315663/98242787-17993d80-1fc1-11eb-86fe-a0c80d7c6823.jpg)
![SS 2020-11-05 at 2 42 40 pm](https://user-images.githubusercontent.com/49315663/98242822-24b62c80-1fc1-11eb-991c-af72dc8b3635.jpg)
![SS 2020-11-05 at 2 43 26 pm](https://user-images.githubusercontent.com/49315663/98242834-297ae080-1fc1-11eb-8d74-3e83d142906d.jpg)
![SS 2020-11-05 at 2 44 22 pm](https://user-images.githubusercontent.com/49315663/98242850-2f70c180-1fc1-11eb-9a42-adb71d795ece.jpg)
![SS 2020-11-05 at 2 44 30 pm](https://user-images.githubusercontent.com/49315663/98242911-41526480-1fc1-11eb-9505-6b00e600d60f.jpg)
![SS 2020-11-05 at 5 23 24 pm](https://user-images.githubusercontent.com/49315663/98242953-55966180-1fc1-11eb-9496-00162063a67b.jpg)
![Nov-05-2020 18-32-47](https://user-images.githubusercontent.com/49315663/98243037-76f74d80-1fc1-11eb-9859-b639619280dc.gif)
![Nov-06-2020 00-01-47](https://user-images.githubusercontent.com/49315663/98244374-73fd5c80-1fc3-11eb-9921-b7641e2629d0.gif)

**Solution:**
[https://trello.com/c/oWXniFwP/26-chncy-025-fix-responsive-issue-front-end](https://trello.com/c/oWXniFwP/26-chncy-025-fix-responsive-issue-front-end)
55d7cc9 Fix show answer button overflow issue on mobile
bb2dc9b Make question and answer container wider on mobile, make question smaller on mobile
4421736 Move previous and next buttons away from the card for mobile
b94eb75 Hide Hot key instructions on mobile
7b48c17 Implement back to top of the card on click hide answer button
594a2d8 Fix tag text over flow on mobile
e1c3db0 Fix tag over flow on mobile
acc9272 Fix tags, count and save button stack together issue on mobile
3566f84 Fix previous and next buttons stay hover issue after clicked on mobile
ebf1ebb Remove excessive padding on flash cards
2a1be74 Make tags the same height
c935e12 Make filter box stable
0fcdb38 Fix app bar overlap on filter box on mobile
8572ecc Add page width boundary
fd10168 Fix clean filter button overflow issue
![SS 2020-11-05 at 11 49 47 pm](https://user-images.githubusercontent.com/49315663/98243349-eb31f100-1fc1-11eb-945e-eeed6b830997.jpg)
![SS 2020-11-05 at 11 50 09 pm](https://user-images.githubusercontent.com/49315663/98243359-ef5e0e80-1fc1-11eb-9650-385f8db09d73.jpg)
![SS 2020-11-05 at 11 50 47 pm](https://user-images.githubusercontent.com/49315663/98243362-f08f3b80-1fc1-11eb-9024-1fb526c5f2fa.jpg)
![SS 2020-11-05 at 11 51 09 pm](https://user-images.githubusercontent.com/49315663/98243366-f38a2c00-1fc1-11eb-9225-aa2f818fa7bf.jpg)
![SS 2020-11-05 at 11 51 17 pm](https://user-images.githubusercontent.com/49315663/98243369-f422c280-1fc1-11eb-9fe5-35f697002834.jpg)
![Nov-05-2020 23-53-25](https://user-images.githubusercontent.com/49315663/98243533-321fe680-1fc2-11eb-8c3a-80fc0891319c.gif)
![Nov-06-2020 00-06-37](https://user-images.githubusercontent.com/49315663/98244734-00a81a80-1fc4-11eb-96c3-2f44b6bca4fa.gif)

**Risk:**
Existing users will be shocked that they can use their mobile devices to easily access the contents. 😱

**Reviewed By:**
Steven Ho
