### PR TITLE
CHNCY-028 Fixing particle rendering bug in mobile mode

### DIFF
--- a/src/components/ParticleComponent.js
+++ b/src/components/ParticleComponent.js
@@ -15,7 +15,10 @@ function ParticleComponent() {
             }}
         >
             <Particles
+                width='100vw'
+                height='100vh'
                 params={{
+                    
                     particles: {
                         color: {
                             value: theme.palette.primary.main


### PR DESCRIPTION
**Issue:**
The particle effect is not rendered in full screen when the screen is made smaller.

BEFORE:
![before](https://user-images.githubusercontent.com/63892309/104881838-e37dc800-59c6-11eb-90d3-3acde7ec6e85.PNG)

AFTER:
![after](https://user-images.githubusercontent.com/63892309/104881856-ec6e9980-59c6-11eb-88f7-4df65c34c2aa.PNG)


**Solution:**
This fix added a height attribute and a width attribute to make sure the partical.js effect is rendered full screen.

**Risk:**
N/A

**Reviewed By:**
Steven Ho