### PR TITLE
Fix when log in account menu pop open

### DIFF
--- a/src/components/AccountMenu.js
+++ b/src/components/AccountMenu.js
@@ -51,6 +51,7 @@ function AccountMenu(props) {
 
   const logout = async () => {
     try {
+      props.onClose();
       await Auth.signOut();
       props.updateAuthState("loggedOut");
       history.push("/");


### PR DESCRIPTION
**Issue:**
Some time account menu will randomly pop when log in back into revise screen

**Solution:**
Close the menu when log out so the variable change to null when logging out.

**Risk:**
The bug might not be fixed but very unlikely

**Reviewed By:**
[Edit the message as to who reviewed it here]
