### PR TITLE
Add check for currentFlashcard so the page doesn't crash

### DIFF
--- a/src/components/Flashcard.js
+++ b/src/components/Flashcard.js
@@ -267,6 +267,7 @@ function Flashcard(props) {
   useEffect(() => {
     if (
       savedCards &&
+      currentFlashcard &&
       savedCards.find((item) => item.flashCardID === currentFlashcard.id)
     ) {
       setSaved(true);


### PR DESCRIPTION
**Issue:**
The page will crash if user goes to revise before cards finish loading

**Solution:**
Add check for currentFlashcard so the page doesn't crash

**Risk:**
N/A

**Reviewed By:**
[Edit the message as to who reviewed it here]
