### PR TITLE
Small screen fixes

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -102,7 +102,7 @@ function Sidebar(props) {
             color: darkMode ? "white" : "black",
           }}
         >
-          <ListItem button>
+          <ListItem button onClick={handleDrawerClose}>
             <ListItemIcon>
               <Home />
             </ListItemIcon>
@@ -117,7 +117,7 @@ function Sidebar(props) {
             color: darkMode ? "white" : "black",
           }}
         >
-          <ListItem button>
+          <ListItem button onClick={handleDrawerClose}>
             <ListItemIcon>
               <ImportContacts />
             </ListItemIcon>
@@ -132,7 +132,7 @@ function Sidebar(props) {
             color: darkMode ? "white" : "black",
           }}
         >
-          <ListItem button>
+          <ListItem button onClick={handleDrawerClose}>
             <ListItemIcon>
               <BookmarkBorder />
             </ListItemIcon>
@@ -165,7 +165,7 @@ function Sidebar(props) {
               color: darkMode ? "white" : "black",
             }}
           >
-            <ListItem button className={classes.nested}>
+            <ListItem button className={classes.nested} onClick={handleDrawerClose}>
               <ListItemIcon>
                 <Settings />
               </ListItemIcon>

--- a/src/components/Socials.jsx
+++ b/src/components/Socials.jsx
@@ -11,6 +11,7 @@ const useStyles = makeStyles((theme) => ({
     bottom: "10px",
     left: "50%",
     transform: "translateX(-50%)",
+    width: "100%",
 
     display: "flex",
     flexDirection: "column",


### PR DESCRIPTION
**Issue:**
the social icons were wrapping on small screens which made it look ugly. You also have to close the side menu manually after 
clicking on a button which is not ideal.

**Solution:**
Don't wrap social links. Call on close every time the user clicks on a link in the side drawer.
